### PR TITLE
Simplified CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,106 +19,19 @@ find_package(Threads REQUIRED)
 ### STATICALLY LINKED LIBRARY
 set(LIBRARY_NAME philslib)
 
-set(LIB_HEADERS
-    include/pl/algo/clamp.hpp
-    include/pl/algo/destroy.hpp
-    include/pl/algo/destroy_at.hpp
-    include/pl/algo/erase.hpp
-    include/pl/algo/for_each_n.hpp
-    include/pl/algo/ranged_algorithms.hpp
-    include/pl/algo/slide.hpp
-    include/pl/algo/uninitialized_default_construct.hpp
-    include/pl/algo/uninitialized_default_construct_n.hpp
-    include/pl/algo/uninitialized_move.hpp
-    include/pl/algo/uninitialized_move_n.hpp
-    include/pl/algo/uninitialized_value_construct.hpp
-    include/pl/algo/uninitialized_value_construct_n.hpp
-    include/pl/cont/back.hpp
-    include/pl/cont/data.hpp
-    include/pl/cont/front.hpp
-    include/pl/cont/make_array.hpp
-    include/pl/cont/size.hpp
-    include/pl/cont/to_array.hpp
-    include/pl/meta/bool_constant.hpp
-    include/pl/meta/conjunction.hpp
-    include/pl/meta/container_traits.hpp
-    include/pl/meta/detection_idiom.hpp
-    include/pl/meta/disable_if.hpp
-    include/pl/meta/disjunction.hpp
-    include/pl/meta/identity.hpp
-    include/pl/meta/is_reference_wrapper.hpp
-    include/pl/meta/iterator_traits.hpp
-    include/pl/meta/negation.hpp
-    include/pl/meta/nested_types.hpp
-    include/pl/meta/none.hpp
-    include/pl/meta/uncvref.hpp
-    include/pl/meta/void_t.hpp
-    include/pl/thd/concurrent.hpp
-    include/pl/thd/monitor.hpp
-    include/pl/thd/then.hpp
-    include/pl/thd/thread_pool.hpp
-    include/pl/thd/thread_safe_queue.hpp
-    include/pl/alloca.hpp
-    include/pl/annotations.hpp
-    include/pl/anonymous_variable.hpp
-    include/pl/apply.hpp
-    include/pl/as_bytes.hpp
-    include/pl/as_const.hpp
-    include/pl/asprintf.hpp
-    include/pl/assert.hpp
-    include/pl/begin_end.hpp
-    include/pl/begin_end_macro.hpp
-    include/pl/bitmask.hpp
-    include/pl/bits.hpp
-    include/pl/bswap.hpp
-    include/pl/byte.hpp
-    include/pl/char_to_int.hpp
-    include/pl/checked_delete.hpp
-    include/pl/compiler.hpp
-    include/pl/concept_poly.hpp
-    include/pl/current_function.hpp
-    include/pl/eprintf.hpp
-    include/pl/except.hpp
-    include/pl/for_each_argument.hpp
-    include/pl/glue.hpp
-    include/pl/hash.hpp
-    include/pl/inline.hpp
-    include/pl/integer.hpp
-    include/pl/invoke.hpp
-    include/pl/iterate_reversed.hpp
-    include/pl/make_from_tuple.hpp
-    include/pl/memxor.hpp
-    include/pl/named_operator.hpp
-    include/pl/negate_predicate.hpp
-    include/pl/no_macro_substitution.hpp
-    include/pl/numeric.hpp
-    include/pl/observer_ptr.hpp
-    include/pl/os.hpp
-    include/pl/overload.hpp
-    include/pl/packed.hpp
-    include/pl/print_bytes_as_hex.hpp
-    include/pl/random_number_generator.hpp
-    include/pl/raw_memory_array.hpp
-    include/pl/raw_storage.hpp
-    include/pl/restrict.hpp
-    include/pl/source_line.hpp
-    include/pl/strdup.hpp
-    include/pl/stringify.hpp
-    include/pl/timer.hpp
-    include/pl/toggle_bool.hpp
-    include/pl/unrelated_pointer_cast.hpp
-    include/pl/unused.hpp
-    include/pl/vla.hpp
-    include/pl/zero_memory.hpp)
+file(GLOB LIB_HEADERS
+    include/pl/algo/*.hpp
+    include/pl/cont/*.hpp
+    include/pl/meta/*.hpp
+    include/pl/thd/*.hpp
+    include/pl/*.hpp)
 
-set(LIB_SOURCES
-    src/pl/thd/thread_pool.cpp
-    src/pl/asprintf.cpp
-    src/pl/eprintf.cpp
-    src/pl/except.cpp
-    src/pl/print_bytes_as_hex.cpp
-    src/pl/strdup.cpp
-    src/pl/timer.cpp)
+file(GLOB LIB_SOURCES
+    src/pl/algo/*.cpp
+    src/pl/cont/*.cpp
+    src/pl/meta/*.cpp
+    src/pl/thd/*.cpp
+    src/pl/*.cpp)
 
 add_library(${LIBRARY_NAME} STATIC "${LIB_HEADERS}" "${LIB_SOURCES}")
 
@@ -132,10 +45,9 @@ set(UNIT_TEST_NAME unittest)
 set(TEST_HEADERS
     test/doctest.h)
 
-set(TEST_SOURCES
-    test/src/test_main.cpp
-    test/src/algo/clamp_test.cpp
-    test/src/algo/erase_test.cpp)
+file(GLOB TEST_SOURCES
+    test/src/algo/*.cpp
+    test/src/*.cpp)
 
 add_executable(${UNIT_TEST_NAME} 
     "${TEST_HEADERS}" 
@@ -146,4 +58,3 @@ target_link_libraries(${UNIT_TEST_NAME} Threads::Threads)
 target_link_libraries(${UNIT_TEST_NAME} ${LIBRARY_NAME})
 
 add_test(Unittest ${UNIT_TEST_NAME})
-


### PR DESCRIPTION
Instead of adding every file individually we can use wildcards which makes things simpler if we decide to add more files.