### PR TITLE
Some macro stuff added

### DIFF
--- a/include/pl/assert.hpp
+++ b/include/pl/assert.hpp
@@ -35,37 +35,6 @@
 #include "except.hpp" // pl::AssertionViolationException, pl::PreconditionViolationException, pl::PostconditionViolationException
 #include <ciso646> // not
 #include <cassert> // NDEBUG
-/*!
- * \def PL_DETAIL_ASSERTION_IMPLEMENTATION(condition, exceptionType, violationTypeString)
- * \brief Implementation macro not to be used directly.
- *
- * Implementation macro used in PL_CHECK_PRE, PL_CHECK_POST, PL_ASSERT, PL_DBG_CHECK_PRE,
- * PL_DBG_CHECK_POST and PL_DBG_ASSERT.
-**/
-
-/*!
- * \def PL_CHECK_PRE(precondition)
- * \brief Macro to check a precondition.
- *
- * Throws pl::PreconditionViolationException with an appropriate message if
- * precondition evaluates to false.
-**/
-
-/*!
- * \def PL_CHECK_POST(postcondition)
- * \brief Macro to check a postcondition.
- *
- * Throws pl::PostconditionViolationException with an appropriate message if
- * postcondition evaluates to false.
-**/
-
-/*!
- * \def PL_ASSERT(condition)
- * \brief Macro to check a condition.
- *
- * Throws pl::AssertionViolationException with an appropriate message if
- * postcondition evaluates to false.
-**/
 
 /*!
  * \def PL_DBG_CHECK_PRE(precondition)
@@ -121,6 +90,14 @@
  * If NDEBUG is defined does nothing.
 **/
 
+
+/*!
+ * \def PL_DETAIL_ASSERTION_IMPLEMENTATION(condition, exceptionType, violationTypeString)
+ * \brief Implementation macro not to be used directly.
+ *
+ * Implementation macro used in PL_CHECK_PRE, PL_CHECK_POST, PL_ASSERT, PL_DBG_CHECK_PRE,
+ * PL_DBG_CHECK_POST and PL_DBG_ASSERT.
+**/
 #define PL_DETAIL_ASSERTION_IMPLEMENTATION(condition, exceptionType, violationTypeString) \
     PL_BEGIN_MACRO \
         if (not (condition)) { \
@@ -132,31 +109,88 @@
         } \
     PL_END_MACRO
 
+/*!
+ * \def PL_DETAIL_ASSERTION_IMPLEMENTATION_MSG(condition, exceptionType, violationTypeString, message)
+ * \brief Implementation macro not to be used directly.
+ *
+ * Implementation macro used in PL_ASSERT_MSG and PL_DBG_ASSERT_MSG.
+**/
+#define PL_DETAIL_ASSERTION_IMPLEMENTATION_MSG(condition, exceptionType, violationTypeString, message) \
+    PL_BEGIN_MACRO \
+        if (not (condition)) { \
+            PL_THROW_WITH_SOURCE_INFO(exceptionType, \
+                violationTypeString " VIOLATION:\n" \
+                 message "\n" \
+                PL_STRINGIFY(condition) \
+                "\nevaluated to false!" \
+            ); \
+        } \
+    PL_END_MACRO
+
+/*!
+ * \def PL_CHECK_PRE(precondition)
+ * \brief Macro to check a precondition.
+ *
+ * Throws pl::PreconditionViolationException with an appropriate message if
+ * precondition evaluates to false.
+**/
 #define PL_CHECK_PRE(precondition) \
     PL_DETAIL_ASSERTION_IMPLEMENTATION(precondition, \
         ::pl::PreconditionViolationException, \
         "PRECONDITION" \
     )
 
+/*!
+ * \def PL_CHECK_POST(postcondition)
+ * \brief Macro to check a postcondition.
+ *
+ * Throws pl::PostconditionViolationException with an appropriate message if
+ * postcondition evaluates to false.
+**/
 #define PL_CHECK_POST(postcondition) \
     PL_DETAIL_ASSERTION_IMPLEMENTATION(postcondition, \
         ::pl::PostconditionViolationException, \
         "POSTCONDITION" \
     )
 
+/*!
+ * \def PL_ASSERT(condition)
+ * \brief Macro to check a condition.
+ *
+ * Throws pl::AssertionViolationException with an appropriate message if
+ * postcondition evaluates to false.
+**/
 #define PL_ASSERT(condition) \
     PL_DETAIL_ASSERTION_IMPLEMENTATION(condition, \
         ::pl::AssertionViolationException, \
         "ASSERTION" \
     )
 
+/*!
+ * \def PL_ASSERT_MSG(condition, message)
+ * \brief Macro to check a condition and display a custom message in case
+ *        that the condition eventuated to false.
+ *
+ * Throws pl::AssertionViolationException with an appropriate message if
+ * postcondition evaluates to false.
+**/
+#define PL_ASSERT_MSG(condition, message) \
+    PL_DETAIL_ASSERTION_IMPLEMENTATION(condition, \
+        ::pl::AssertionViolationException, \
+        "ASSERTION", \
+        message \
+    )
+
 #ifdef NDEBUG
 #   define PL_DBG_CHECK_PRE(precondition) PL_BEGIN_MACRO PL_END_MACRO /* do nothing */
 #   define PL_DBG_CHECK_POST(postcondition) PL_BEGIN_MACRO PL_END_MACRO  /* do nothing */
 #   define PL_DBG_ASSERT(condition) PL_BEGIN_MACRO PL_END_MACRO  /* do nothing */
+#   define PL_DBG_ASSERT_MSG(condition, message) PL_BEGIN_MACRO PL_END_MACRO /* do nothing */
 #else
 #   define PL_DBG_CHECK_PRE(precondition) PL_CHECK_PRE(precondition)
 #   define PL_DBG_CHECK_POST(postcondition) PL_CHECK_POST(postcondition)
 #   define PL_DBG_ASSERT(condition) PL_ASSERT(condition)
+#   define PL_DBG_ASSERT_MSG(condition, message) PL_ASSERT_MSG(condition, message)
 #endif
+
 #endif // INCG_PL_ASSERT_HPP

--- a/include/pl/compiler.hpp
+++ b/include/pl/compiler.hpp
@@ -55,9 +55,9 @@
 **/
 
 /*!
- * \def PL_COMPILER_UNKNOWN
- * \brief PL_COMPILER will be defined as this if the compiler being used
- *        could not be determined.
+* \def PL_COMPILER_UNKNOWN
+* \brief PL_COMPILER will be defined as this if the compiler being used
+*        could not be determined.
 **/
 
 /*!
@@ -66,6 +66,25 @@
  *        PL_COMPILER_MSVC, PL_COMPILER_GCC or PL_COMPILER_UNKNOWN
  *        depending on which compiler is being used.
 **/
+
+#define PL_COMPILER_CLANG (0x0000) /* meaningless number */
+#define PL_COMPILER_ICC (0x0001) /* meaningless number */
+#define PL_COMPILER_MSVC (0x0002) /* meaningless number */
+#define PL_COMPILER_GCC (0x0003) /* meaningless number */
+#define PL_COMPILER_UNKNOWN (0xFFFF) /* meaningless number */
+
+#if defined(__clang__)
+#   define PL_COMPILER PL_COMPILER_CLANG
+#elif defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC)
+#   define PL_COMPILER PL_COMPILER_ICC
+#elif defined(_MSC_VER)
+#   define PL_COMPILER PL_COMPILER_MSVC
+#elif defined(__GNUC__) || defined(__GNUG__)
+#   define PL_COMPILER PL_COMPILER_GCC
+#else
+#   define PL_COMPILER PL_COMPILER_UNKNOWN
+#   warning "Compiler could not be detected"
+#endif
 
 /*!
  * \def PL_COMPILER_MAJOR
@@ -83,62 +102,51 @@
 **/
 
 /*!
+ * \def PL_COMPILER_NAME
+ * \brief The name of the compiler.
+**/
+
+#if PL_COMPILER == PL_COMPILER_CLANG
+#   define PL_COMPILER_MAJOR __clang_major__
+#   define PL_COMPILER_MINOR __clang_minor__
+#   define PL_COMPILER_PATCH __clang_patchlevel__
+#   define PL_COMPILER_NAME "Clang"
+#elif PL_COMPILER == PL_COMPILER_ICC
+#   define PL_COMPILER_MAJOR __INTEL_COMPILER / 100
+#   define PL_COMPILER_MINOR __INTEL_COMPILER % 100 / 10
+#   define PL_COMPILER_PATCH __INTEL_COMPILER % 10
+#   define PL_COMPILER_NAME "Intel ICC"
+#elif PL_COMPILER == PL_COMPILER_MSVC
+#   define PL_COMPILER_MAJOR _MSC_FULL_VER / 10000000
+#   define PL_COMPILER_MINOR _MSC_FULL_VER % 10000000 / 100000
+#   define PL_COMPILER_PATCH _MSC_FULL_VER % 100000
+#   define PL_COMPILER_NAME "Microsoft Visual Studio"
+#elif PL_COMPILER == PL_COMPILER_GCC
+#   define PL_COMPILER_MAJOR __GNUC__
+#   define PL_COMPILER_MINOR __GNUC_MINOR__
+#   define PL_COMPILER_PATCH __GNUC_PATCHLEVEL__
+#   define PL_COMPILER_NAME "GCC"
+#else
+#   define PL_COMPILER_MAJOR (0x00) /* 0 for unknown compiler */
+#   define PL_COMPILER_MINOR (0x00) /* 0 for unknown compiler */
+#   define PL_COMPILER_PATCH (0x00) /* 0 for unknown compiler */
+#   define PL_COMPILER_NAME "Unknown"
+#endif
+
+/*!
  * \def PL_COMPILER_VERSION_CHECK(major, minor, patch)
  * \brief Can be used to create a compiler version using a major, minor
  *        and patch number. Useful to compare the current compiler version
  *        to a specific version.
 **/
+#define PL_COMPILER_VERSION_CHECK(major, minor, patch) \
+    (((major) * 16777216) + ((minor) * 65536) + (patch)) /* multipliers to 'push' the numbers leftward */
 
 /*!
  * \def PL_COMPILER_VERSION
  * \brief The current compiler version, may be compared to a number generated
  *        with PL_COMPILER_VERSION_CHECK
 **/
-
-#define PL_COMPILER_CLANG (0x0004) /* meaningless number */
-#define PL_COMPILER_ICC (0x0005) /* meaningless number */
-#define PL_COMPILER_MSVC (0x0006) /* meaningless number */
-#define PL_COMPILER_GCC (0x0007) /* meaningless number */
-#define PL_COMPILER_UNKNOWN (0x0008) /* meaningless number */
-
-#if defined(__clang__)
-#   define PL_COMPILER PL_COMPILER_CLANG
-#elif defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC)
-#   define PL_COMPILER PL_COMPILER_ICC
-#elif defined(_MSC_VER)
-#   define PL_COMPILER PL_COMPILER_MSVC
-#elif defined(__GNUC__) || defined(__GNUG__)
-#   define PL_COMPILER PL_COMPILER_GCC
-#else
-#   define PL_COMPILER PL_COMPILER_UNKNOWN
-#   warning "Compiler could not be detected"
-#endif
-
-#if PL_COMPILER == PL_COMPILER_CLANG
-    #define PL_COMPILER_MAJOR __clang_major__
-    #define PL_COMPILER_MINOR __clang_minor__
-    #define PL_COMPILER_PATCH __clang_patchlevel__
-#elif PL_COMPILER == PL_COMPILER_ICC
-    #define PL_COMPILER_MAJOR __INTEL_COMPILER / 100
-    #define PL_COMPILER_MINOR __INTEL_COMPILER % 100 / 10
-    #define PL_COMPILER_PATCH __INTEL_COMPILER % 10
-#elif PL_COMPILER == PL_COMPILER_MSVC
-    #define PL_COMPILER_MAJOR _MSC_FULL_VER / 10000000
-    #define PL_COMPILER_MINOR _MSC_FULL_VER % 10000000 / 100000
-    #define PL_COMPILER_PATCH _MSC_FULL_VER % 100000
-#elif PL_COMPILER == PL_COMPILER_GCC
-    #define PL_COMPILER_MAJOR __GNUC__
-    #define PL_COMPILER_MINOR __GNUC_MINOR__
-    #define PL_COMPILER_PATCH __GNUC_PATCHLEVEL__
-#else
-    #define PL_COMPILER_MAJOR (0x00) /* 0 for unknown compiler */
-    #define PL_COMPILER_MINOR (0x00) /* 0 for unknown compiler */
-    #define PL_COMPILER_PATCH (0x00) /* 0 for unknown compiler */
-#endif
-
-#define PL_COMPILER_VERSION_CHECK(major, minor, patch) \
-    (((major) * 16777216) + ((minor) * 65536) + (patch)) /* multipliers to 'push' the numbers leftward */
-
 #define PL_COMPILER_VERSION \
     PL_COMPILER_VERSION_CHECK(PL_COMPILER_MAJOR, PL_COMPILER_MINOR, PL_COMPILER_PATCH)
 

--- a/include/pl/except.hpp
+++ b/include/pl/except.hpp
@@ -36,6 +36,7 @@
 #include "stringify.hpp" // PL_STRINGIFY
 #include <string> // std::string
 #include <stdexcept> // std::runtime_error
+
 /*!
  * \def PL_DEFINE_EXCEPTION_TYPE(exceptionTypeIdentifier, baseClass)
  * \brief Defines an exception type. Its name will be exceptionTypeIdentifier
@@ -43,37 +44,6 @@
  *        in the current namespace. This macro makes defining new exception
  *        types a lot more convenient by generating a lot of boilerplate code.
 **/
-
-/*!
- * \def PL_THROW_WITH_SOURCE_INFO(exceptionType, message)
- * \brief Throws an exception of type exceptionType with the message message
- *        including information regarding where the exception was thrown.
- * \note Note that the line number may have been manipulated using #line.
- *
- * Includes the file, line and function from where the exception was thrown
- * in the message of the exception object of type exceptionType that can be
- * accessed via the .what() member function. The first parameter of this macro
- * must be an exception type, that type will be the type of the exception
- * thrown by the macro. The second parameter of the macro is the message
- * of the user to include in the exception object's message, std::string must
- * be constructible from message.
-**/
-
-/*!
- * \def PL_THROW_IF_NULL(pointer)
- * \brief Throws pl::NullPointerException if the pointer passed in is null.
- * \note Uses PL_THROW_WITH_SOURCE_INFO internally.
- * \see PL_THROW_WITH_SOURCE_INFO
-**/
-
-/*!
- * \def PL_NOT_YET_IMPLEMENTED
- * \brief Throws pl::NotYetImplementedException. Can be used to 'implement'
- *        functions that are net yet implmented so that they throw when called.
- * \note Uses PL_THROW_WITH_SOURCE_INFO internally.
- * \see PL_THROW_WITH_SOURCE_INFO
-**/
-
 #define PL_DEFINE_EXCEPTION_TYPE(exceptionTypeIdentifier, baseClass) \
     class exceptionTypeIdentifier \
         : public baseClass \
@@ -94,6 +64,20 @@
         \
     }
 
+/*!
+ * \def PL_THROW_WITH_SOURCE_INFO(exceptionType, message)
+ * \brief Throws an exception of type exceptionType with the message message
+ *        including information regarding where the exception was thrown.
+ * \note Note that the line number may have been manipulated using #line.
+ *
+ * Includes the file, line and function from where the exception was thrown
+ * in the message of the exception object of type exceptionType that can be
+ * accessed via the .what() member function. The first parameter of this macro
+ * must be an exception type, that type will be the type of the exception
+ * thrown by the macro. The second parameter of the macro is the message
+ * of the user to include in the exception object's message, std::string must
+ * be constructible from message.
+**/
 #define PL_THROW_WITH_SOURCE_INFO(exceptionType, message) \
     throw exceptionType{ \
         "Message: " \
@@ -105,6 +89,12 @@
         + std::string{ PL_CURRENT_FUNCTION } \
     }
 
+/*!
+ * \def PL_THROW_IF_NULL(pointer)
+ * \brief Throws pl::NullPointerException if the pointer passed in is null.
+ * \note Uses PL_THROW_WITH_SOURCE_INFO internally.
+ * \see PL_THROW_WITH_SOURCE_INFO
+**/
 #define PL_THROW_IF_NULL(pointer) \
     PL_BEGIN_MACRO \
     if ((pointer) == nullptr) { \
@@ -113,6 +103,13 @@
     } \
     PL_END_MACRO
 
+/*!
+ * \def PL_NOT_YET_IMPLEMENTED
+ * \brief Throws pl::NotYetImplementedException. Can be used to 'implement'
+ *        functions that are net yet implemented so that they throw when called.
+ * \note Uses PL_THROW_WITH_SOURCE_INFO internally.
+ * \see PL_THROW_WITH_SOURCE_INFO
+**/
 #define PL_NOT_YET_IMPLEMENTED() \
     PL_THROW_WITH_SOURCE_INFO(pl::NotYetImplementedException, \
         "function has not yet been implemented!")

--- a/include/pl/os.hpp
+++ b/include/pl/os.hpp
@@ -30,6 +30,7 @@
 **/
 #ifndef INCG_PL_OS_HPP
 #define INCG_PL_OS_HPP
+
 /*!
  * \def PL_OS_WINDOWS
  * \brief PL_OS will be defined as this if the operating system used is
@@ -45,8 +46,26 @@
 /*!
  * \def PL_OS_LINUX
  * \brief PL_OS will be defined as this if the operating system used is
- *        GNU/Linux
+ *        GNU/Linux.
  * \note Everything running a linux kernel will be considered linux.
+**/
+
+/*!
+ * \def PL_OS_ANDROID
+ * \brief PL_OS will be defined as this if the operating system used is
+ *        Android.
+**/
+
+/*!
+ * \def PL_OS_FREEBSD
+ * \brief PL_OS will be defined as this if the operating system used is
+ *        FreeBSD.
+**/
+
+/*!
+ * \def PL_OS_SOLARIS
+ * \brief PL_OS will be defined as this if the operating system used is
+ *        Oracle Solaris.
 **/
 
 /*!
@@ -57,23 +76,51 @@
 
 /*!
  * \def PL_OS
- * \brief Will be defined as PL_OS_WINDOWS, PL_OS_MAC, PL_OS_LINUX or
- *        PL_OS_UNKNOWN
+ * \brief Will be defined as PL_OS_WINDOWS, PL_OS_MAC, PL_OS_LINUX,
+ *        PL_OS_ANDROID, PL_OS_FREEBSD, PL_OS_SOLARIS or PL_OS_UNKNOWN
+**/
+
+/*!
+ * \def PL_OS_NAME
+ * \brief The name of the operating system.
 **/
 
 #define PL_OS_WINDOWS (0x0000) /* meaningless number */
 #define PL_OS_MAC (0x0001) /* meaningless number */
 #define PL_OS_LINUX (0x0002) /* meaningless number */
-#define PL_OS_UNKNOWN (0x0003) /* meaningless number */
+#define PL_OS_ANDROID (0x0003) /* meaningless number */
+#define PL_OS_FREEBSD (0x0004) /* meaningless number */
+#define PL_OS_SOLARIS (0x0005) /* meaningless number */
+#define PL_OS_UNKNOWN (0xFFFF) /* meaningless number */
 
 #if defined(_WIN32)
 #   define PL_OS PL_OS_WINDOWS
+#   define PL_OS_NAME "Windows"
 #elif defined(__APPLE__)
 #   define PL_OS PL_OS_MAC
-#elif defined(__linux__)
-#   define PL_OS PL_OS_LINUX
+#   define PL_OS_NAME "MacOS"
+#elif defined(__unix__)
+#   if defined(__linux__)
+#       define PL_OS PL_OS_LINUX
+#       define PL_OS_NAME "Linux"
+#   elif defined(__ANDROID__)
+#       define PL_OS PL_OS_ANDROID
+#       define PL_OS_NAME "Android"
+#   elif defined(__FreeBSD__)
+#       define PL_OS PL_OS_FREEBSD
+#       define PL_OS_NAME "FreeBSD"
+#   else
+#       define PL_OS PL_OS_UNKNOWN
+#       define PL_OS_NAME "Unknown"
+#       warning "Unknown Unix based operating system"
+#   endif
+#elif defined(__sun) && defined(__SVR4)
+#   define PL_OS PL_OS_SOLARIS
+#   define PL_OS_NAME "Solaris"
 #else
 #   define PL_OS PL_OS_UNKNOWN
+#   define PL_OS_NAME "Unknown"
 #   warning "Operating system could not be detected"
 #endif
+
 #endif // INCG_PL_OS_HPP

--- a/include/pl/os.hpp
+++ b/include/pl/os.hpp
@@ -100,12 +100,12 @@
 #   define PL_OS PL_OS_MAC
 #   define PL_OS_NAME "MacOS"
 #elif defined(__unix__)
-#   if defined(__linux__)
-#       define PL_OS PL_OS_LINUX
-#       define PL_OS_NAME "Linux"
-#   elif defined(__ANDROID__)
+#   if defined(__ANDROID__)
 #       define PL_OS PL_OS_ANDROID
 #       define PL_OS_NAME "Android"
+#   elif defined(__linux__)
+#       define PL_OS PL_OS_LINUX
+#       define PL_OS_NAME "Linux"
 #   elif defined(__FreeBSD__)
 #       define PL_OS PL_OS_FREEBSD
 #       define PL_OS_NAME "FreeBSD"


### PR DESCRIPTION
Added PL_ASSERT_MSG and PL_DBG_ASSERT_MSG do the same like the original macro but also allow the user to specify a custom message.
Added PL_COMPILER_NAME and PL_OS_NAME cause why not. Could be used in log files something similar to let the developer know which operating system was used.
Added Android, FreeBSD and Solaris as detectable operating systems.
Moved some comments around to allow IDEs like Visuals Studio to display these information's inside the editor without having to open the specific file.